### PR TITLE
Updated DOMPDF Font Cache

### DIFF
--- a/dompdf/lib/fonts/dompdf_font_family_cache.dist.php
+++ b/dompdf/lib/fonts/dompdf_font_family_cache.dist.php
@@ -129,4 +129,11 @@
     'italic' => DOMPDF_FONT_DIR . 'Meta-Medium-Regular',
     'bold_italic' => DOMPDF_FONT_DIR . 'Meta-Medium-Regular',
   ),
+  'open sans italic' => 
+  array (
+    'normal' => DOMPDF_FONT_DIR . 'OpenSans_Italic',
+    'bold' => DOMPDF_FONT_DIR . 'OpenSans_Italic',
+    'italic' => DOMPDF_FONT_DIR . 'OpenSans_Italic',
+    'bold_italic' => DOMPDF_FONT_DIR . 'OpenSans_Italic',
+  ),
 ) ?>


### PR DESCRIPTION
Updated the DOMPDF Font Cache since the Open Sans Italic font did not render properly with the previous addition.

PS : The Open Sans Italic font is required for the back side of the FSA Card.
